### PR TITLE
Added additional class for half size columns on mobile view

### DIFF
--- a/css/amazium.css
+++ b/css/amazium.css
@@ -155,9 +155,8 @@
 .grid_5, .grid_6, .grid_7, .grid_8,
 .grid_9, .grid_10, .grid_11, .grid_12           { width:100%; margin:10px 0 0 0; float:none; display:block; }
 
-.grid_6_mobile                                  { width: 48%; float: left; }
-.grid_6_mobile + .grid_6_mobile                 { float: right; }
-
+.grid_6_mobile                                  { width:48%; float:left; }
+.grid_6_mobile + .grid_6_mobile                 { float:right; }
 
 .show-mobile                                    { display:inherit !important; }
 .show-tablet                                    { display:none !important; }


### PR DESCRIPTION
Usage: **.grid_6_mobile**

Currently only set up to work alone or in pairs. Alone will float a 48% width column to the left, in pairs will include a second column floated to the right.

Overrides default 100% width column on mobile view.

``` html
<section class="row">
    <article class="grid_2 grid_6_mobile">2 Desktop - Half Mobile</article>
    <article class="grid_2 grid_6_mobile">2 Desktop - Half Mobile</article>
</section>
```
