### PR TITLE
Add table row stripes using tbody striped class

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -130,8 +130,8 @@ caption                                         { margin:0 0 10px; }
 
 tr                                              { background-color:#FFF; transition:all .1s linear 0s; -moz-transition:all .1s linear 0s; -webkit-transition:all .1s linear 0s; -o-transition:all .1s linear 0s; }
 tr:hover                                        { background-color:#F1F1F1; transition:all .1s linear 0s; -moz-transition:all .1s linear 0s; -webkit-transition:all .1s linear 0s; -o-transition:all .1s linear 0s; }
-tr.even                                         { background-color:#FFF; }
-tr.odd                                          { background-color:#F1F1F1; }
+tbody.striped tr:nth-child(even), tr.even       { background-color:#FFF; }
+tbody.striped tr:nth-child(odd), tr.odd         { background-color:#F1F1F1; }
 
 th                                              { padding:8px; background-color:#F1F1F1; color:#222; font-weight:bold; border:none; border-bottom:3px solid #D6D6D6; text-align:left; white-space:nowrap; }
 

--- a/example.html
+++ b/example.html
@@ -95,7 +95,7 @@
         <hr />
         <h3>Tables</h3>
         <table summary="This is an example of a table">
-            <tbody>
+            <tbody class="striped">
                 <tr>
                     <th scope="col">#ID:</th>
                     <th scope="col">First Name:</th>

--- a/example.html
+++ b/example.html
@@ -94,6 +94,9 @@
         </p>
         <hr />
         <h3>Tables</h3>
+        <p>
+            Add row striping to your table by adding the "striped" class to the tbody tag.  This is supported by all modern browsers.  If you really need to support striping for IE 8 or earlier then add the "odd" / "even" classes to alternate rows to achieve the same effect.
+        </p>
         <table summary="This is an example of a table">
             <tbody class="striped">
                 <tr>

--- a/example.html
+++ b/example.html
@@ -95,7 +95,7 @@
         <hr />
         <h3>Tables</h3>
         <p>
-            Add row striping to your table by adding the "striped" class to the tbody tag.  This is supported by all modern browsers.  If you really need to support striping for IE 8 or earlier then add the "odd" / "even" classes to alternate rows to achieve the same effect.
+            Add row striping to your table by adding the "striped" class to the tbody tag.  This is supported by all modern browsers.  If you need to support striping for IE 8 or earlier then add the "odd" / "even" classes to alternate rows to achieve the same effect.
         </p>
         <table summary="This is an example of a table">
             <tbody class="striped">


### PR DESCRIPTION
Creating table stripes with a class on tbody makes for simpler logic when generating table content in a template using iteration.

1.  Add table row stripes using tbody striped class for modern browsers. Older browsers use odd/even classes or just live with the fact that tables aren't striped in older browsers.

2. Update example.html to demonstrate table row striping