### PR TITLE
Fixed unwanted spacing between nested rows

### DIFF
--- a/css/amazium.css
+++ b/css/amazium.css
@@ -9,7 +9,7 @@
 Screen 1200px+
 ***********************************************/
 .row                                            { margin:0 auto; width:1200px; display:table; }
-.row .row                                       { margin:0 -20px; width:auto; display:inline-block; }
+.row .row                                       { margin:0 -20px; width:auto; }
 
 .grid_1                                         { width:60px; margin:0 20px; float:left; display:inline; }
 .grid_2                                         { width:160px; margin:0 20px; float:left; display:inline; }
@@ -155,7 +155,7 @@ Mobile
 @media only screen and (max-width: 767px) {
 
 .row                                            { padding:0 16px; width:100%; display:block; box-sizing:border-box; -webkit-box-sizing:border-box; -moz-box-sizing:border-box; }
-.row .row                                       { margin:0; padding:0; width:100%; display:block; }
+.row .row                                       { margin:0; padding:0; width:100%; }
 
 .grid_1, .grid_2, .grid_3, .grid_4,
 .grid_5, .grid_6, .grid_7, .grid_8,


### PR DESCRIPTION
I've got some nested rows as described on the [setup guide](http://www.amazium.co.uk/setup.html), however there seems to be some extra spacing between each of the rows.

An example of the issue can be found here: http://jsfiddle.net/s6LbkLfw/1/embedded/result/

The issue seems to be caused by white space between the `div` elements when they have `display: inline-block;` on the nested `.row .row` class. Initially I thought to change the `display: inline-block;` to `float: left;`. But, unless I've missed something, I can't see any use for having `display: inline-block;` as each `.row` element is an entire row and shouldn't have anything beside it. So removing these from the `.row .row` class solves the issue and I haven't experienced any drawbacks.

This [Stack Overflow](http://stackoverflow.com/questions/11805352/floatleft-vs-displayinline-vs-displayinline-block-vs-displaytable-cell) discussion helped solve the issue.

You can experiment with the fix here: http://jsfiddle.net/s6LbkLfw/1/