### PR TITLE
[row--width-fluid] Fixes override width issue 

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -47,6 +47,7 @@ Tablet - This applies from 768px onwards
 
   /***** Row setup *****/
   .row                                          { width:$grid-width-tablet; }
+  .row--width-fluid                             { width:100%; }
 
   /***** Grid gutters *****/
   %grid-styles-tablet                           { @include padding(0 $grid-gutter-tablet); }
@@ -76,6 +77,7 @@ Smaller screen - This applies from 992px onwards
 
   /***** Row setup *****/
   .row                                          { width:$grid-width-smscreen; }
+  .row--width-fluid                             { width:100%; }
 
   /***** Grid gutters *****/
   %grid-styles-smscreen                         { @include padding(0 $grid-gutter-smscreen); }
@@ -95,6 +97,7 @@ Screen - This applies from 1200px onwards
 
   /***** Row setup *****/
   .row                                          { width:$grid-width; }
+  .row--width-fluid                             { width:100%; }
 
   /***** Grid gutters *****/
   %grid-styles                                  { @include padding(0 $grid-gutter); }

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -10,7 +10,7 @@ Mobile First - This applies from 0px to 767px
 
 /***** Row setup *****/
 .row                                            { margin:0 auto; padding:0 20px; display:flex; flex-direction:row; box-sizing:border-box; flex:0 1 auto; flex-wrap:wrap; }
-.row--width-fluid                               { @extend .row; width:100%; }
+.row--width-fluid                               { margin:0 auto; padding:0 20px; display:flex; flex-direction:row; box-sizing:border-box; flex:0 1 auto; flex-wrap:wrap; width:100%; }
 
 /***** Row alignments *****/
 .row--align-left                                { justify-content:flex-start; }
@@ -47,7 +47,6 @@ Tablet - This applies from 768px onwards
 
   /***** Row setup *****/
   .row                                          { width:$grid-width-tablet; }
-  .row--width-fluid                             { width:100%; }
 
   /***** Grid gutters *****/
   %grid-styles-tablet                           { @include padding(0 $grid-gutter-tablet); }
@@ -77,7 +76,6 @@ Smaller screen - This applies from 992px onwards
 
   /***** Row setup *****/
   .row                                          { width:$grid-width-smscreen; }
-  .row--width-fluid                             { width:100%; }
 
   /***** Grid gutters *****/
   %grid-styles-smscreen                         { @include padding(0 $grid-gutter-smscreen); }
@@ -97,7 +95,6 @@ Screen - This applies from 1200px onwards
 
   /***** Row setup *****/
   .row                                          { width:$grid-width; }
-  .row--width-fluid                             { width:100%; }
 
   /***** Grid gutters *****/
   %grid-styles                                  { @include padding(0 $grid-gutter); }


### PR DESCRIPTION
Had to add in ```witdh:100%;``` to all media queries as the ```@extend``` was using the row width instead.