### PR TITLE
[Grid] Fixes grid in Safari and issue #102

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -37,7 +37,7 @@ Mobile First - This applies from 0px to 767px
 
 /***** Sets mobile override grid width *****/
 @for $i from 1 through $grid-columns {
-  .grid-#{$i}-mobile                            { flex-grow:$i; max-width:$i / $grid-columns * 100%; }
+  .grid-#{$i}-mobile                            { flex-basis:$i / $grid-columns * 100%; }
 }
 
 /***********************************************
@@ -49,13 +49,13 @@ Tablet - This applies from 768px onwards
   .row                                          { width:$grid-width-tablet; }
 
   /***** Grid gutters *****/
-  %grid-styles-tablet                           { flex:0; @include padding(0 $grid-gutter-tablet); }
+  %grid-styles-tablet                           { @include padding(0 $grid-gutter-tablet); }
 
   /***** Sets grid widths *****/
   .grid                                         { flex:1 1 0%; @extend %grid-styles-tablet; }
 
   @for $i from 1 through $grid-columns          {
-    .grid-#{$i}                                 { flex-grow:$i; max-width:100% / $grid-columns *$i; @extend %grid-styles-tablet; }
+    .grid-#{$i}                                 { flex-basis:100% / $grid-columns *$i; @extend %grid-styles-tablet; }
   }
 
   /***** Sets grid offsets *****/
@@ -114,7 +114,7 @@ Tablet - This applies from 768px to 992px
 
   /***** Sets table override grid width *****/
   @for $i from 1 through $grid-columns          {
-    .grid-#{$i}-tablet                          { flex-grow:$i; max-width:$i / $grid-columns * 100%; }
+    .grid-#{$i}-tablet                          { flex-basic:$i / $grid-columns * 100%; }
   }
 
   /***** Grid ordering *****/
@@ -123,7 +123,7 @@ Tablet - This applies from 768px to 992px
 
   /***** Sets tablet override grid width *****/
   @for $i from 1 through $grid-columns {
-    .grid-#{$i}-tablet                          { flex-grow:$i; max-width:$i / $grid-columns * 100%; }
+    .grid-#{$i}-tablet                          { flex-basic:$i / $grid-columns * 100%; }
   }
 }
 


### PR DESCRIPTION
Removes flex, flex-grow and max-width and replaces with flex-basic to fix safari issue as well as letting you have more grids in a row that need to wrap.

Fixes #102 