### PR TITLE
added option to deactivate offsets

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -59,8 +59,10 @@ Tablet - This applies from 768px onwards
   }
 
   /***** Sets grid offsets *****/
-  @for $i from 1 through $grid-columns - 1      {
-    .grid--offset-#{$i}                         { margin-left:100% / $grid-columns *$i; }
+  @if ($offsets) {
+    @for $i from 1 through $grid-columns - 1      {
+      .grid--offset-#{$i}                         { margin-left:100% / $grid-columns *$i; }
+    }
   }
 
   /***** Grid ordering *****/

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -23,6 +23,9 @@ $grid-gutter:20px;
 $grid-gutter-smscreen:$grid-gutter / 1.25;
 $grid-gutter-tablet:$grid-gutter-smscreen / 1.1;
 
+/***** Activate or deactivate offsets *****/
+$offsets: true;
+
 /***** Shorthand Padding Mixin *****/
 @mixin padding($padding) { padding:$padding; }
 


### PR DESCRIPTION
I added the option to deactivate the generation of `.grid--offset-XX` It's a small code change but why generate css if you don't need it. By default it is activated and if set to `false` the offset classes won't be generated which ultimately saves you about 0.5KB ;)